### PR TITLE
Fix numeric sorting of locals by local union number

### DIFF
--- a/lib/providers/app_state_provider.dart
+++ b/lib/providers/app_state_provider.dart
@@ -409,11 +409,41 @@ class AppStateProvider extends ChangeNotifier {
         return LocalsRecord.fromFirestore(doc);
       }).toList();
       
+      // Sort locals numerically by local union number
+      newLocals.sort((a, b) {
+        // Try to parse local union numbers as integers for proper numeric sorting
+        final aNum = int.tryParse(a.localUnion.replaceAll(RegExp(r'[^0-9]'), ''));
+        final bNum = int.tryParse(b.localUnion.replaceAll(RegExp(r'[^0-9]'), ''));
+        
+        // If both can be parsed as numbers, sort numerically
+        if (aNum != null && bNum != null) {
+          return aNum.compareTo(bNum);
+        }
+        // If one is numeric and the other isn't, numeric comes first
+        if (aNum != null) return -1;
+        if (bNum != null) return 1;
+        // If neither is numeric, sort alphabetically
+        return a.localUnion.compareTo(b.localUnion);
+      });
+      
       if (isRefresh) {
         _locals = newLocals;
         _lastLocalDocument = snapshot.docs.isNotEmpty ? snapshot.docs.last : null;
       } else {
         _locals.addAll(newLocals);
+        // Resort the entire list after adding new locals
+        _locals.sort((a, b) {
+          final aNum = int.tryParse(a.localUnion.replaceAll(RegExp(r'[^0-9]'), ''));
+          final bNum = int.tryParse(b.localUnion.replaceAll(RegExp(r'[^0-9]'), ''));
+          
+          if (aNum != null && bNum != null) {
+            return aNum.compareTo(bNum);
+          }
+          if (aNum != null) return -1;
+          if (bNum != null) return 1;
+          return a.localUnion.compareTo(b.localUnion);
+        });
+        
         if (snapshot.docs.isNotEmpty) {
           _lastLocalDocument = snapshot.docs.last;
         }
@@ -455,6 +485,24 @@ class AppStateProvider extends ChangeNotifier {
       }).toList();
       
       _locals.addAll(newLocals);
+      
+      // Resort the entire list after adding more locals to maintain numeric order
+      _locals.sort((a, b) {
+        // Try to parse local union numbers as integers for proper numeric sorting
+        final aNum = int.tryParse(a.localUnion.replaceAll(RegExp(r'[^0-9]'), ''));
+        final bNum = int.tryParse(b.localUnion.replaceAll(RegExp(r'[^0-9]'), ''));
+        
+        // If both can be parsed as numbers, sort numerically
+        if (aNum != null && bNum != null) {
+          return aNum.compareTo(bNum);
+        }
+        // If one is numeric and the other isn't, numeric comes first
+        if (aNum != null) return -1;
+        if (bNum != null) return 1;
+        // If neither is numeric, sort alphabetically
+        return a.localUnion.compareTo(b.localUnion);
+      });
+      
       if (snapshot.docs.isNotEmpty) {
         _lastLocalDocument = snapshot.docs.last;
       }


### PR DESCRIPTION
## Summary
- Enhances sorting of locals by their local union numbers to be numeric rather than lexicographic
- Ensures consistent ordering when locals are fetched or appended

## Changes

### Core Functionality
- Added numeric parsing and sorting logic for `localUnion` strings in `AppStateProvider`
- Applied sorting after fetching new locals and after appending locals to maintain correct order
- Handles cases where local union numbers contain non-numeric characters by extracting digits
- Falls back to alphabetical sorting if numeric parsing is not possible

## Test plan
- [ ] Verify locals are sorted numerically by their local union numbers on initial load
- [ ] Confirm sorting remains correct after loading more locals
- [ ] Test with locals having non-numeric or mixed local union strings to ensure fallback sorting
- [ ] Check no regressions in locals display and ordering in the UI

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/a1b4c8af-5f7f-4cf0-b7d8-24d73f9d1274